### PR TITLE
working_seeker_with_audio_example

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -76,7 +76,7 @@ class _MyAppState extends State<MyApp> {
   }
 
   void startPlayer() async{
-    String path = await flutterSound.startPlayer(null);
+    String path = await flutterSound.startPlayer('https://firebasestorage.googleapis.com/v0/b/the-best-rapper.appspot.com/o/dope_rap_beat.mp3?alt=media&token=174bb1aa-90ab-42c0-8573-fb3dbd0d5989');
     await flutterSound.setVolume(1.0);
     print('startPlayer: $path');
 
@@ -254,17 +254,14 @@ class _MyAppState extends State<MyApp> {
               crossAxisAlignment: CrossAxisAlignment.center,
             ),
             Container(
-              width: 56.0,
               height: 56.0,
               child: Slider(
                 value: slider_current_position,
                 min: 0.0,
                 max: max_duration,
-//                onChanged: (double value) {
-//                  setState(() async{
-//                    String result = await flutterSound.seekToPlayer(value.toInt());
-//                  });
-//                },
+                onChanged: (double value) async{
+                  await flutterSound.seekToPlayer(value.toInt());
+                },
                 divisions: max_duration.toInt()
               )
             )

--- a/example/test/unit_test.dart
+++ b/example/test/unit_test.dart
@@ -1,8 +1,8 @@
-import 'package:test/test.dart';
+// import 'package:test/test.dart';
 
-void main() {
-  test('my first unit test', () {
-    var answer = 11;
-    expect(answer, 11);
-  });
-}
+// void main() {
+//   test('my first unit test', () {
+//     var answer = 11;
+//     expect(answer, 11);
+//   });
+// }

--- a/example/test/unit_test.dart
+++ b/example/test/unit_test.dart
@@ -1,8 +1,0 @@
-// import 'package:test/test.dart';
-
-// void main() {
-//   test('my first unit test', () {
-//     var answer = 11;
-//     expect(answer, 11);
-//   });
-// }


### PR DESCRIPTION
I added an example audio source that comes from my Google Firebase Storage so we can see a working demonstration to test the seeker and other player controls. The seeker works fine, you're able to press or drag anywhere in the seeker to go to that song's position. The seeker now fills the container's width, too. The onChanged property takes in a double value, which is the new value that the user has pressed or dragged to, and we use that value to seek the player to that new value, and that is why we have to convert it to an int, because flutterSound.seekToPlayer method takes an int value to seek.