### PR TITLE
Fix file URI for recording and playing in iOS

### DIFF
--- a/ios/Classes/FlutterSoundPlugin.m
+++ b/ios/Classes/FlutterSoundPlugin.m
@@ -140,8 +140,9 @@ FlutterMethodChannel* _channel;
   if ([path class] == [NSNull class]) {
     audioFileURL = [NSURL fileURLWithPath:[NSTemporaryDirectory() stringByAppendingString:@"sound.m4a"]];
   } else {
-    audioFileURL = [NSURL fileURLWithPath:[NSTemporaryDirectory() stringByAppendingString:path]];
+    audioFileURL = [NSURL fileURLWithPath:path];
   }
+  NSLog(@"HERE");
 
   NSDictionary *audioSettings = [NSDictionary dictionaryWithObjectsAndKeys:
                                  [NSNumber numberWithFloat:[sampleRate doubleValue]],AVSampleRateKey,
@@ -181,12 +182,12 @@ FlutterMethodChannel* _channel;
 
 - (void)startPlayer:(NSString*)path result: (FlutterResult)result {
   if ([path class] == [NSNull class]) {
-    path = @"sound.m4a";
+    audioFileURL = [NSURL fileURLWithPath:[NSTemporaryDirectory() stringByAppendingString:@"sound.m4a"]];
+  } else {
+    audioFileURL = [NSURL fileURLWithPath:path];
   }
 
-  if ([[path substringToIndex:4] isEqualToString:@"http"]) {
-    audioFileURL = [NSURL URLWithString:path];
-
+  if ([[audioFileURL.absoluteString substringToIndex:4] isEqualToString:@"http"]) {
     NSURLSessionDataTask *downloadTask = [[NSURLSession sharedSession]
         dataTaskWithURL:audioFileURL completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
             // NSData *data = [NSData dataWithContentsOfURL:audioFileURL];
@@ -211,8 +212,6 @@ FlutterMethodChannel* _channel;
 
     [downloadTask resume];
   } else {
-    audioFileURL = [NSURL fileURLWithPath:[NSTemporaryDirectory() stringByAppendingString:path]];
-
     // if (!audioPlayer) { // Fix sound distoring when playing recorded audio again.
       audioPlayer = [[AVAudioPlayer alloc] initWithContentsOfURL:audioFileURL error:nil];
       audioPlayer.delegate = self;


### PR DESCRIPTION
Android startPlayer/startRecorder assumes the given URI is absolute, while iOS assumes the URI is relative to the temporary directory. In practice this means that a valid full path given to Android would not work on iOS. This changes iOS to interpret given URIs as full paths.

E.g. passing the URI

```
/<path_to_app>/Documents/recordings/file.m4a
```

Gets translated to the (invalid, notice the double slash `"//"` and the repeated `<path_to_app>`) URI in iOS

```
/<path_to_app>/tmp//<path_to_app>/Documents/recordings/file.m4a
```
