### PR TITLE
Feature/db meter

### DIFF
--- a/android/src/main/java/com/dooboolab/fluttersound/FlutterSoundPlugin.java
+++ b/android/src/main/java/com/dooboolab/fluttersound/FlutterSoundPlugin.java
@@ -60,7 +60,7 @@ public class FlutterSoundPlugin implements MethodCallHandler, PluginRegistry.Req
         result.success("Android " + android.os.Build.VERSION.RELEASE);
         break;
       case "startRecorder":
-        int sampleRate = (int) Math.round((Double) call.argument("sampleRate"));
+        int sampleRate = call.argument("sampleRate");
         int numChannels = call.argument("numChannels");
         this.startRecorder(numChannels, sampleRate, path, result);
         break;


### PR DESCRIPTION
The last merge into master missed a line and broke the Android startRecorder.
This happened because *sampleRate* used to be a *Double* and I changed it to *Int* (on the db-meter branch) and during the last merge into master, the old Android *startRecorder()* method was kept.
This fixes it.