### PR TITLE
Fix/ios remote playing

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -91,7 +91,7 @@ class _MyAppState extends State<MyApp> {
   }
 
   void startPlayer() async{
-    String path = await flutterSound.startPlayer('https://firebasestorage.googleapis.com/v0/b/the-best-rapper.appspot.com/o/dope_rap_beat.mp3?alt=media&token=174bb1aa-90ab-42c0-8573-fb3dbd0d5989');
+    String path = await flutterSound.startPlayer(null);
     await flutterSound.setVolume(1.0);
     print('startPlayer: $path');
 

--- a/ios/Classes/FlutterSoundPlugin.m
+++ b/ios/Classes/FlutterSoundPlugin.m
@@ -252,10 +252,10 @@ NSString* status = [NSString stringWithFormat:@"{\"current_position\": \"%@\"}",
     NSURLSessionDataTask *downloadTask = [[NSURLSession sharedSession]
         dataTaskWithURL:audioFileURL completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
             // NSData *data = [NSData dataWithContentsOfURL:audioFileURL];
-      if (!self->audioPlayer) {
+            
+        // We must create a new Audio Player instance to be able to play a different Url
+        self->audioPlayer = [[AVAudioPlayer alloc] initWithData:data error:nil];
         self->audioPlayer.delegate = self;
-      }
-      self->audioPlayer = [[AVAudioPlayer alloc] initWithData:data error:nil];
 
         // Able to play in silent mode
         [[AVAudioSession sharedInstance]


### PR DESCRIPTION
This fixes iOS not playing remote audio files when the protocol is not **http**.
It also fixes the the sound player not playing the correct remote file when startPlayer() is called with a different url (also iOS).