### PR TITLE
Allow BitRate customisation

### DIFF
--- a/android/src/main/java/com/dooboolab/fluttersound/AudioInterface.java
+++ b/android/src/main/java/com/dooboolab/fluttersound/AudioInterface.java
@@ -3,7 +3,7 @@ package com.dooboolab.fluttersound;
 import io.flutter.plugin.common.MethodChannel;
 
 interface AudioInterface {
-  void startRecorder(int numChannels, int sampleRate, int androidEncoder, String path, MethodChannel.Result result);
+  void startRecorder(int numChannels, int sampleRate, Integer bitRate, int androidEncoder, String path, MethodChannel.Result result);
   void stopRecorder(MethodChannel.Result result);
   void startPlayer(String path, MethodChannel.Result result);
   void stopPlayer(MethodChannel.Result result);

--- a/android/src/main/java/com/dooboolab/fluttersound/AudioModel.java
+++ b/android/src/main/java/com/dooboolab/fluttersound/AudioModel.java
@@ -5,7 +5,7 @@ import android.media.MediaRecorder;
 import android.os.Environment;
 
 public class AudioModel {
-  final public static String DEFAULT_FILE_LOCATION = Environment.getExternalStorageDirectory().getPath() + "/default.mp4";
+  final public static String DEFAULT_FILE_LOCATION = Environment.getExternalStorageDirectory().getPath() + "/default.m4a";
   public int subsDurationMillis = 10;
   public long peakLevelUpdateMillis = 800;
   public boolean shouldProcessDbLevel = true;

--- a/android/src/main/java/com/dooboolab/fluttersound/FlutterSoundPlugin.java
+++ b/android/src/main/java/com/dooboolab/fluttersound/FlutterSoundPlugin.java
@@ -63,7 +63,8 @@ public class FlutterSoundPlugin implements MethodCallHandler, PluginRegistry.Req
         int sampleRate = call.argument("sampleRate");
         int numChannels = call.argument("numChannels");
         int androidEncoder = call.argument("androidEncoder");
-        this.startRecorder(numChannels, sampleRate, androidEncoder, path, result);
+        Integer bitRate = call.argument("bitRate");
+        this.startRecorder(numChannels, sampleRate, bitRate, androidEncoder, path, result);
         break;
       case "stopRecorder":
         this.stopRecorder(result);
@@ -120,7 +121,7 @@ public class FlutterSoundPlugin implements MethodCallHandler, PluginRegistry.Req
   }
 
   @Override
-  public void startRecorder(int numChannels, int sampleRate, int androidEncoder, String path, final Result result) {
+  public void startRecorder(int numChannels, int sampleRate, Integer bitRate, int androidEncoder, String path, final Result result) {
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
       if (
           reg.activity().checkSelfPermission(Manifest.permission.RECORD_AUDIO) != PackageManager.PERMISSION_GRANTED
@@ -148,7 +149,13 @@ public class FlutterSoundPlugin implements MethodCallHandler, PluginRegistry.Req
       this.model.getMediaRecorder().setAudioEncoder(androidEncoder);
       this.model.getMediaRecorder().setAudioChannels(numChannels);
       this.model.getMediaRecorder().setAudioSamplingRate(sampleRate);
+
       this.model.getMediaRecorder().setOutputFile(path);
+
+      // If bitrate is defined, the use it, otherwise use the OS default
+      if(bitRate != null){
+        this.model.getMediaRecorder().setAudioEncodingBitRate(bitRate);
+      }
     }
 
     try {

--- a/lib/flutter_sound.dart
+++ b/lib/flutter_sound.dart
@@ -114,9 +114,9 @@ class FlutterSound {
         'path': uri,
         'sampleRate': sampleRate,
         'numChannels': numChannels,
+        'bitRate': bitRate,
         'androidEncoder': androidEncoder?.value,
-        'iosQuality': iosQuality?.value,
-        'bitRate': bitRate
+        'iosQuality': iosQuality?.value
       });
       _setRecorderCallback();
 

--- a/lib/flutter_sound.dart
+++ b/lib/flutter_sound.dart
@@ -104,11 +104,10 @@ class FlutterSound {
   }
 
   Future<String> startRecorder(String uri,
-      {int sampleRate = 44100, int numChannels = 2,
+      {int sampleRate = 44100, int numChannels = 2, int bitRate,
         AndroidEncoder androidEncoder = AndroidEncoder.AAC,
         IosQuality iosQuality = IosQuality.LOW
       }) async {
-    print("IOS ENCODER ${iosQuality.value}");
     try {
       String result =
       await _channel.invokeMethod('startRecorder', <String, dynamic>{
@@ -116,7 +115,8 @@ class FlutterSound {
         'sampleRate': sampleRate,
         'numChannels': numChannels,
         'androidEncoder': androidEncoder?.value,
-        'iosQuality': iosQuality?.value
+        'iosQuality': iosQuality?.value,
+        'bitRate': bitRate
       });
       _setRecorderCallback();
 


### PR DESCRIPTION
This PR implements bitRate customisation for both Android/iOS targets. This is particularly useful for Android where the default bitrate is very low (poor quality).
I also renamed the default android extension from .**mp4** to .**m4a** since this is the recommended for MPEG-4 audio files and it now matches iOS.