### PR TITLE
Fix: bitRate nullability check for iOS was wrong and throwing an exception when bitRate was not specified

### DIFF
--- a/android/src/main/java/com/dooboolab/fluttersound/FlutterSoundPlugin.java
+++ b/android/src/main/java/com/dooboolab/fluttersound/FlutterSoundPlugin.java
@@ -195,7 +195,7 @@ public class FlutterSoundPlugin implements MethodCallHandler, PluginRegistry.Req
           public void run() {
             //int ratio = model.getMediaRecorder().getMaxAmplitude() / micBase;
             double dbLevel = 20 * Math.log10(model.getMediaRecorder().getMaxAmplitude() / model.micLevelBase);
-            double normalizedDbLevel = Math.min(Math.pow(10, dbLevel / 20.0) * 120.0, 120);
+            double normalizedDbLevel = Math.min(Math.pow(10, dbLevel / 20.0) * 160.0, 160.0);
             channel.invokeMethod("updateDbPeakProgress", normalizedDbLevel);
             dbPeakLevelHandler.postDelayed(model.getDbLevelTicker(), (FlutterSoundPlugin.this.model.peakLevelUpdateMillis));
           }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -179,7 +179,7 @@ class _MyAppState extends State<MyApp> {
                   ),
                 ),
                 _isRecording ? LinearProgressIndicator(
-                  value: 100.0 / 120.0 * (this._dbLevel ?? 1) / 100,
+                  value: 100.0 / 160.0 * (this._dbLevel ?? 1) / 100,
                   valueColor: AlwaysStoppedAnimation<Color>(Colors.green),
                   backgroundColor: Colors.red,
                 ) : Container()

--- a/ios/Classes/FlutterSoundPlugin.m
+++ b/ios/Classes/FlutterSoundPlugin.m
@@ -195,7 +195,7 @@ NSString* status = [NSString stringWithFormat:@"{\"current_position\": \"%@\"}",
                                  [NSNumber numberWithInt: [iosQuality intValue]],AVEncoderAudioQualityKey,nil];
     
     // If bitrate is defined, the use it, otherwise use the OS default
-    if(bitRate != nil) {
+    if(![bitRate isEqual:[NSNull null]]) {
         [audioSettings setValue:[NSNumber numberWithInt: [bitRate intValue]]
                     forKey:AVEncoderBitRateKey];
     }

--- a/ios/Classes/FlutterSoundPlugin.m
+++ b/ios/Classes/FlutterSoundPlugin.m
@@ -76,7 +76,7 @@ NSString* status = [NSString stringWithFormat:@"{\"current_position\": \"%@\"}",
 
 - (void)updateDbPeakProgress:(NSTimer*) dbPeakTimer
 {
-      NSNumber *normalizedPeakLevel = [NSNumber numberWithDouble:MIN(pow(10.0, [audioRecorder peakPowerForChannel:0] / 20.0) * 120.0, 120)];
+      NSNumber *normalizedPeakLevel = [NSNumber numberWithDouble:MIN(pow(10.0, [audioRecorder peakPowerForChannel:0] / 20.0) * 160.0, 160.0)];
       [_channel invokeMethod:@"updateDbPeakProgress" arguments:normalizedPeakLevel];
 }
 


### PR DESCRIPTION
Also adjusted the dbPeak range (to 0-160)