### PR TITLE
Android command queue for recording related tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.3.6
++ Android: Adds a single threaded command scheduler for all recording related
+  commands.
++ Switch source & target compability to Java 8
++ Bump gradle plugin version dependencies
+
 ## 1.3.+
 + Support db/meter [#41](https://github.com/dooboolab/flutter_sound/pull/41)
 + Show wrong recorder timer text [#47](https://github.com/dooboolab/flutter_sound/pull/47)

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.2'
+        classpath 'com.android.tools.build:gradle:3.3.2'
     }
 }
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -31,4 +31,8 @@ android {
     lintOptions {
         disable 'InvalidPackage'
     }
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
 }

--- a/android/src/main/java/com/dooboolab/fluttersound/FlutterSoundPlugin.java
+++ b/android/src/main/java/com/dooboolab/fluttersound/FlutterSoundPlugin.java
@@ -56,9 +56,6 @@ public class FlutterSoundPlugin implements MethodCallHandler, PluginRegistry.Req
   public void onMethodCall(MethodCall call, Result result) {
     String path = call.argument("path");
     switch (call.method) {
-      case "getPlatformVersion":
-        result.success("Android " + android.os.Build.VERSION.RELEASE);
-        break;
       case "startRecorder":
         int sampleRate = call.argument("sampleRate");
         int numChannels = call.argument("numChannels");

--- a/android/src/main/java/com/dooboolab/fluttersound/FlutterSoundPlugin.java
+++ b/android/src/main/java/com/dooboolab/fluttersound/FlutterSoundPlugin.java
@@ -14,6 +14,8 @@ import org.json.JSONObject;
 
 import java.util.Timer;
 import java.util.TimerTask;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
@@ -34,6 +36,7 @@ public class FlutterSoundPlugin implements MethodCallHandler, PluginRegistry.Req
   private static final String ERR_RECORDER_IS_NULL = "ERR_RECORDER_IS_NULL";
   private static final String ERR_RECORDER_IS_RECORDING = "ERR_RECORDER_IS_RECORDING";
 
+  private final ExecutorService taskScheduler = Executors.newSingleThreadExecutor();
 
   private static Registrar reg;
   final private AudioModel model = new AudioModel();
@@ -50,19 +53,20 @@ public class FlutterSoundPlugin implements MethodCallHandler, PluginRegistry.Req
   }
 
   @Override
-  public void onMethodCall(MethodCall call, Result result) {
-    String path = call.argument("path");
+  public void onMethodCall(final MethodCall call, final Result result) {
+    final String path = call.argument("path");
     switch (call.method) {
       case "startRecorder":
-        int sampleRate = call.argument("sampleRate");
-        int numChannels = call.argument("numChannels");
-        int androidEncoder = call.argument("androidEncoder");
-        Integer bitRate = call.argument("bitRate");
-        this.startRecorder(numChannels, sampleRate, bitRate, androidEncoder, path, result);
+        taskScheduler.submit(() -> {
+          int sampleRate = call.argument("sampleRate");
+          int numChannels = call.argument("numChannels");
+          int androidEncoder = call.argument("androidEncoder");
+          Integer bitRate = call.argument("bitRate");
+          startRecorder(numChannels, sampleRate, bitRate, androidEncoder, path, result);
+        });
         break;
       case "stopRecorder":
-        this.stopRecorder(result);
-        break;
+        taskScheduler.submit(() -> stopRecorder(result));
       case "startPlayer":
         this.startPlayer(path, result);
         break;

--- a/android/src/main/java/com/dooboolab/fluttersound/FlutterSoundPlugin.java
+++ b/android/src/main/java/com/dooboolab/fluttersound/FlutterSoundPlugin.java
@@ -12,9 +12,6 @@ import android.util.Log;
 import org.json.JSONException;
 import org.json.JSONObject;
 
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
-import java.util.Locale;
 import java.util.Timer;
 import java.util.TimerTask;
 
@@ -162,40 +159,34 @@ public class FlutterSoundPlugin implements MethodCallHandler, PluginRegistry.Req
       // Remove all pending runnables, this is just for safety (should never happen)
       recordHandler.removeCallbacksAndMessages(null);
       final long systemTime = SystemClock.elapsedRealtime();
-      this.model.setRecorderTicker(new Runnable() {
-        @Override
-        public void run() {
+      this.model.setRecorderTicker(() -> {
 
-          long time = SystemClock.elapsedRealtime() - systemTime;
+        long time = SystemClock.elapsedRealtime() - systemTime;
 //          Log.d(TAG, "elapsedTime: " + SystemClock.elapsedRealtime());
 //          Log.d(TAG, "time: " + time);
 
 //          DateFormat format = new SimpleDateFormat("mm:ss:SS", Locale.US);
 //          String displayTime = format.format(time);
 //          model.setRecordTime(time);
-          try {
-            JSONObject json = new JSONObject();
-            json.put("current_position", String.valueOf(time));
-            channel.invokeMethod("updateRecorderProgress", json.toString());
-            recordHandler.postDelayed(model.getRecorderTicker(), model.subsDurationMillis);
-          } catch (JSONException je) {
-            Log.d(TAG, "Json Exception: " + je.toString());
-          }
+        try {
+          JSONObject json = new JSONObject();
+          json.put("current_position", String.valueOf(time));
+          channel.invokeMethod("updateRecorderProgress", json.toString());
+          recordHandler.postDelayed(model.getRecorderTicker(), model.subsDurationMillis);
+        } catch (JSONException je) {
+          Log.d(TAG, "Json Exception: " + je.toString());
         }
       });
       recordHandler.post(this.model.getRecorderTicker());
 
       if(this.model.shouldProcessDbLevel) {
         dbPeakLevelHandler.removeCallbacksAndMessages(null);
-        this.model.setDbLevelTicker(new Runnable() {
-          @Override
-          public void run() {
-            //int ratio = model.getMediaRecorder().getMaxAmplitude() / micBase;
-            double dbLevel = 20 * Math.log10(model.getMediaRecorder().getMaxAmplitude() / model.micLevelBase);
-            double normalizedDbLevel = Math.min(Math.pow(10, dbLevel / 20.0) * 160.0, 160.0);
-            channel.invokeMethod("updateDbPeakProgress", normalizedDbLevel);
-            dbPeakLevelHandler.postDelayed(model.getDbLevelTicker(), (FlutterSoundPlugin.this.model.peakLevelUpdateMillis));
-          }
+        this.model.setDbLevelTicker(() -> {
+          //int ratio = model.getMediaRecorder().getMaxAmplitude() / micBase;
+          double dbLevel = 20 * Math.log10(model.getMediaRecorder().getMaxAmplitude() / model.micLevelBase);
+          double normalizedDbLevel = Math.min(Math.pow(10, dbLevel / 20.0) * 160.0, 160.0);
+          channel.invokeMethod("updateDbPeakProgress", normalizedDbLevel);
+          dbPeakLevelHandler.postDelayed(model.getDbLevelTicker(), (FlutterSoundPlugin.this.model.peakLevelUpdateMillis));
         });
         dbPeakLevelHandler.post(this.model.getDbLevelTicker());
       }
@@ -248,60 +239,54 @@ public class FlutterSoundPlugin implements MethodCallHandler, PluginRegistry.Req
         this.model.getMediaPlayer().setDataSource(path);
       }
 
-      this.model.getMediaPlayer().setOnPreparedListener(new MediaPlayer.OnPreparedListener() {
-        @Override
-        public void onPrepared(final MediaPlayer mp) {
-          Log.d(TAG, "mediaPlayer prepared and start");
-          mp.start();
+      this.model.getMediaPlayer().setOnPreparedListener(mp -> {
+        Log.d(TAG, "mediaPlayer prepared and start");
+        mp.start();
 
-          /*
-           * Set timer task to send event to RN.
-           */
-          TimerTask mTask = new TimerTask() {
-            @Override
-            public void run() {
-              // long time = mp.getCurrentPosition();
-              // DateFormat format = new SimpleDateFormat("mm:ss:SS", Locale.US);
-              // final String displayTime = format.format(time);
-              try {
-                JSONObject json = new JSONObject();
-                json.put("duration", String.valueOf(mp.getDuration()));
-                json.put("current_position", String.valueOf(mp.getCurrentPosition()));
-                channel.invokeMethod("updateProgress", json.toString());
-              } catch (JSONException je) {
-                Log.d(TAG, "Json Exception: " + je.toString());
-              }
+        /*
+         * Set timer task to send event to RN.
+         */
+        TimerTask mTask = new TimerTask() {
+          @Override
+          public void run() {
+            // long time = mp.getCurrentPosition();
+            // DateFormat format = new SimpleDateFormat("mm:ss:SS", Locale.US);
+            // final String displayTime = format.format(time);
+            try {
+              JSONObject json = new JSONObject();
+              json.put("duration", String.valueOf(mp.getDuration()));
+              json.put("current_position", String.valueOf(mp.getCurrentPosition()));
+              channel.invokeMethod("updateProgress", json.toString());
+            } catch (JSONException je) {
+              Log.d(TAG, "Json Exception: " + je.toString());
             }
-          };
+          }
+        };
 
-          mTimer.schedule(mTask, 0, model.subsDurationMillis);
-          String resolvedPath = path == null ? AudioModel.DEFAULT_FILE_LOCATION : path;
-          result.success((resolvedPath));
-        }
+        mTimer.schedule(mTask, 0, model.subsDurationMillis);
+        String resolvedPath = path == null ? AudioModel.DEFAULT_FILE_LOCATION : path;
+        result.success((resolvedPath));
       });
       /*
        * Detect when finish playing.
        */
-      this.model.getMediaPlayer().setOnCompletionListener(new MediaPlayer.OnCompletionListener() {
-        @Override
-        public void onCompletion(MediaPlayer mp) {
-          /*
-           * Reset player.
-           */
-          Log.d(TAG, "Plays completed.");
-          try {
-            JSONObject json = new JSONObject();
-            json.put("duration", String.valueOf(mp.getDuration()));
-            json.put("current_position", String.valueOf(mp.getCurrentPosition()));
-            channel.invokeMethod("audioPlayerDidFinishPlaying", json.toString());
-          } catch (JSONException je) {
-            Log.d(TAG, "Json Exception: " + je.toString());
-          }
-          mTimer.cancel();
-          mp.stop();
-          mp.release();
-          model.setMediaPlayer(null);
+      this.model.getMediaPlayer().setOnCompletionListener(mp -> {
+        /*
+         * Reset player.
+         */
+        Log.d(TAG, "Plays completed.");
+        try {
+          JSONObject json = new JSONObject();
+          json.put("duration", String.valueOf(mp.getDuration()));
+          json.put("current_position", String.valueOf(mp.getCurrentPosition()));
+          channel.invokeMethod("audioPlayerDidFinishPlaying", json.toString());
+        } catch (JSONException je) {
+          Log.d(TAG, "Json Exception: " + je.toString());
         }
+        mTimer.cancel();
+        mp.stop();
+        mp.release();
+        model.setMediaPlayer(null);
       });
       this.model.getMediaPlayer().prepare();
     } catch (Exception e) {

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -48,6 +48,10 @@ android {
             signingConfig signingConfigs.debug
         }
     }
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
 }
 
 flutter {

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.2'
+        classpath 'com.android.tools.build:gradle:3.3.2'
     }
 }
 

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jun 23 08:50:38 CEST 2017
+#Mon Mar 18 08:30:09 CST 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-all.zip

--- a/ios/Classes/FlutterSoundPlugin.m
+++ b/ios/Classes/FlutterSoundPlugin.m
@@ -123,9 +123,7 @@ NSString* status = [NSString stringWithFormat:@"{\"current_position\": \"%@\"}",
 }
 
 - (void)handleMethodCall:(FlutterMethodCall*)call result:(FlutterResult)result {
-  if ([@"getPlatformVersion" isEqualToString:call.method]) {
-    result([@"iOS " stringByAppendingString:[[UIDevice currentDevice] systemVersion]]);
-  } else if ([@"startRecorder" isEqualToString:call.method]) {
+  if ([@"startRecorder" isEqualToString:call.method]) {
     NSString* path = (NSString*)call.arguments[@"path"];
     NSNumber* sampleRate = (NSNumber*)call.arguments[@"sampleRate"];
     NSNumber* numChannels = (NSNumber*)call.arguments[@"numChannels"];

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_sound
 description: Flutter plugin that relates to sound like audio and recorder.
-version: 1.3.5
+version: 1.3.6
 author: dooboolab<dooboolab@gmail.com>
 homepage: https://github.com/dooboolab/flutter_sound
 environment:


### PR DESCRIPTION
This adds a single threaded command queue fo all recording commands on Android (start/stop) as this could have caused interference when users started/stopped recording very quickly.

The PR also contains a few other changes to the build environment and removes a bit of dead code.
@hyochan please let me know if you'd like these changes in a separate set of PRs.

Fixes: #53, #61 