### PR TITLE
AndroidX compatibility improved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.3.7+1
++ Android: Remove reference to non-AndroidX classes which improves compatibility
+
+## 1.3.7
++ No changes.
+
 ## 1.3.6
 + Android: Adds a single threaded command scheduler for all recording related
   commands.

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,11 +22,10 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 27
+    compileSdkVersion 28
 
     defaultConfig {
         minSdkVersion 16
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
     lintOptions {
         disable 'InvalidPackage'

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -25,7 +25,7 @@ apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 27
+    compileSdkVersion 28
 
     lintOptions {
         disable 'InvalidPackage'
@@ -35,10 +35,9 @@ android {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.dooboolab.fluttersoundexample"
         minSdkVersion 16
-        targetSdkVersion 27
+        targetSdkVersion 28
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
 
     buildTypes {
@@ -60,6 +59,4 @@ flutter {
 
 dependencies {
     testImplementation 'junit:junit:4.12'
-    androidTestImplementation 'com.android.support.test:runner:1.0.2'
-    androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_sound
 description: Flutter plugin that relates to sound like audio and recorder.
-version: 1.3.7
+version: 1.3.7+1
 author: dooboolab<dooboolab@gmail.com>
 homepage: https://github.com/dooboolab/flutter_sound
 environment:


### PR DESCRIPTION
This PR essentially increases compile & minSDK version to 28 and removes unused references to legacy test runners, which in turn is enough to ensure AndroidX compatibility.

<img width="456" alt="Screen Shot 2019-03-22 at 10 34 59" src="https://user-images.githubusercontent.com/269860/54797375-dab6f080-4c8e-11e9-8ef8-86638d4a7cc8.png">

Nonetheless tests should be created for this project at some stage. :-)

@hyochan pub version & change log already updated - you can release once merged.
