### PR TITLE
iOS: Fixes for seekToPlayer 

### DIFF
--- a/ios/Classes/FlutterSoundPlugin.m
+++ b/ios/Classes/FlutterSoundPlugin.m
@@ -357,8 +357,9 @@ NSString* status = [NSString stringWithFormat:@"{\"current_position\": \"%@\"}",
 
 - (void)seekToPlayer:(nonnull NSNumber*) time result: (FlutterResult)result {
   if (audioPlayer) {
-    audioPlayer.currentTime = [time doubleValue];
-    result(time);
+      audioPlayer.currentTime = [time doubleValue] / 1000;
+      [self updateProgress:nil];
+      result([time stringValue]);
   } else {
     result([FlutterError
         errorWithCode:@"Audio Player"


### PR DESCRIPTION
`seekToPlayer` on Android returns a String, and on iOS was returning an int. This is reflected in Issue #70. This PR fixes that, making iOS match the Android behaviour.
The iOS `AVAudioPlayer` class's `currentTime` property is measured in seconds instead of milliseconds. This PR converts milliseconds into seconds when setting the current time in the `seekToPlayer` function.
Additionally, the `seekToPlayer` function wasn't calling the `updateProgress` Dart method, which was happening on Android. This PR also adds equivalent functionality to iOS.