### PR TITLE
iOS: Setup configuration for using bluetooth microphone recording input

### DIFF
--- a/ios/Classes/FlutterSoundPlugin.m
+++ b/ios/Classes/FlutterSoundPlugin.m
@@ -205,7 +205,11 @@ NSString* status = [NSString stringWithFormat:@"{\"current_position\": \"%@\"}",
   // set volume default to speaker
   UInt32 doChangeDefaultRoute = 1;
   AudioSessionSetProperty(kAudioSessionProperty_OverrideCategoryDefaultToSpeaker, sizeof(doChangeDefaultRoute), &doChangeDefaultRoute);
-
+  
+  // set up for bluetooth microphone input
+  UInt32 allowBluetoothInput = 1;
+  AudioSessionSetProperty (kAudioSessionProperty_OverrideCategoryEnableBluetoothInput,sizeof (allowBluetoothInput),&allowBluetoothInput);
+ 
   audioRecorder = [[AVAudioRecorder alloc]
                         initWithURL:audioFileURL
                         settings:audioSettings


### PR DESCRIPTION
This is a small change but a very useful configuration on iOS side that will allow the user to capture a bluetooth-headset microphone stream audio when its paired with the phone and set as default input.
If user doesn't have a paired headset, it will work normally using the internal microphone as expected.
