### PR TITLE
fix(example): remove milliseconds conversion

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -149,9 +149,7 @@ class _MyAppState extends State<MyApp> {
   }
 
   void seekToPlayer(int milliSecs) async{
-    int secs = Platform.isIOS ? milliSecs / 1000 : milliSecs;
-
-    String result = await flutterSound.seekToPlayer(secs);
+    String result = await flutterSound.seekToPlayer(milliSecs);
     print('seekToPlayer: $result');
   }
 


### PR DESCRIPTION
`seekToPlayer()` takes milliseconds as input on iOS now. We can remove this conditional check from the example because it is no longer valid.