### PR TITLE
Stopped recording generating infinite db values.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,12 @@ build/
 .idea/
 flutter_sound.iml
 flutter_sound_android.iml
+android/.settings/org.eclipse.buildship.core.prefs
+.vscode/launch.json
+android/.classpath
+android/.project
+example/android/.project
+example/android/.settings/org.eclipse.buildship.core.prefs
+example/android/app/.classpath
+example/android/app/.project
+example/android/app/.settings/org.eclipse.buildship.core.prefs

--- a/android/src/main/java/com/dooboolab/fluttersound/FlutterSoundPlugin.java
+++ b/android/src/main/java/com/dooboolab/fluttersound/FlutterSoundPlugin.java
@@ -199,11 +199,17 @@ public class FlutterSoundPlugin implements MethodCallHandler, PluginRegistry.Req
             // https://stackoverflow.com/questions/10655703/what-does-androids-getmaxamplitude-function-for-the-mediarecorder-actually-gi
             // 
             double ref_pressure = 51805.5336;
-            double p = maxAmplitude / ref_pressure;
+            double p = maxAmplitude  / ref_pressure;
             double p0 = 0.0002;
+
             double db = 20.0 * Math.log10(p / p0);
 
-            // Log.d(TAG, "Amp1: " + maxAmplitude + " Base DB: " + db);
+            // if the microphone is off we get 0 for the amplitude which causes
+            // db to be infinite.
+            if (Double.isInfinite(db))
+              db = 0.0;
+
+            Log.d(TAG, "rawAmplitude: " + maxAmplitude + " Base DB: " + db);
 
             channel.invokeMethod("updateDbPeakProgress", db);
             dbPeakLevelHandler.postDelayed(model.getDbLevelTicker(),

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -16,7 +16,7 @@ class MyApp extends StatefulWidget {
 
 class _MyAppState extends State<MyApp> {
   bool _isRecording = false;
-  bool _isPlaying = false;
+  // bool _isPlaying = false;
   StreamSubscription _recorderSubscription;
   StreamSubscription _dbPeakSubscription;
   StreamSubscription _playerSubscription;
@@ -26,8 +26,8 @@ class _MyAppState extends State<MyApp> {
   String _playerTxt = '00:00:00';
   double _dbLevel;
 
-  double slider_current_position = 0.0;
-  double max_duration = 1.0;
+  double sliderCurrentPosition = 0.0;
+  double maxDuration = 1.0;
 
 
   @override
@@ -101,8 +101,8 @@ class _MyAppState extends State<MyApp> {
     try {
       _playerSubscription = flutterSound.onPlayerStateChanged.listen((e) {
         if (e != null) {
-          slider_current_position = e.currentPosition;
-          max_duration = e.duration;
+          sliderCurrentPosition = e.currentPosition;
+          maxDuration = e.duration;
 
 
           DateTime date = new DateTime.fromMillisecondsSinceEpoch(
@@ -110,7 +110,7 @@ class _MyAppState extends State<MyApp> {
               isUtc: true);
           String txt = DateFormat('mm:ss:SS', 'en_GB').format(date);
           this.setState(() {
-            this._isPlaying = true;
+            //this._isPlaying = true;
             this._playerTxt = txt.substring(0, 8);
           });
         }
@@ -130,7 +130,7 @@ class _MyAppState extends State<MyApp> {
       }
 
       this.setState(() {
-        this._isPlaying = false;
+        //this._isPlaying = false;
       });
     } catch (err) {
       print('error: $err');
@@ -280,13 +280,13 @@ class _MyAppState extends State<MyApp> {
             Container(
               height: 56.0,
               child: Slider(
-                value: slider_current_position,
+                value: sliderCurrentPosition,
                 min: 0.0,
-                max: max_duration,
+                max: maxDuration,
                 onChanged: (double value) async{
                   await flutterSound.seekToPlayer(value.toInt());
                 },
-                divisions: max_duration.toInt()
+                divisions: maxDuration.toInt()
               )
             )
           ],

--- a/lib/flutter_sound.dart
+++ b/lib/flutter_sound.dart
@@ -80,6 +80,7 @@ class FlutterSound {
         default:
           throw new ArgumentError('Unknown method ${call.method}');
       }
+      return null;
     });
   }
 


### PR DESCRIPTION
Added check for a maxAmplitude of zero which can happen if the mic is off which was resulting in db being set to infinity. Db is now set to zero.

This problem may only be an issue with the simulator, but its annoying enough in development that this simple fix is warrented.

This pull also includes some code cleanup to remove a number of lint warnings.
