### PR TITLE
Bugfix #139

### DIFF
--- a/android/src/main/java/com/dooboolab/fluttersound/FlutterSoundPlugin.java
+++ b/android/src/main/java/com/dooboolab/fluttersound/FlutterSoundPlugin.java
@@ -143,8 +143,6 @@ public class FlutterSoundPlugin implements MethodCallHandler, PluginRegistry.Req
 
     if (path == null) {
       path = AudioModel.DEFAULT_FILE_LOCATION;
-    } else {
-      path = Environment.getExternalStorageDirectory().getPath() + "/" + path;
     }
 
     if (this.model.getMediaRecorder() == null) {

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -44,7 +44,7 @@ class _MyAppState extends State<MyApp> {
 
   void startRecorder() async{
     try {
-      String path = await flutterSound.startRecorder(Platform.isIOS ? 'ios.m4a' : 'android.mp4');
+      String path = await flutterSound.startRecorder(null);
       print('startRecorder: $path');
 
       _recorderSubscription = flutterSound.onRecorderStateChanged.listen((e) {

--- a/ios/Classes/FlutterSoundPlugin.m
+++ b/ios/Classes/FlutterSoundPlugin.m
@@ -189,7 +189,7 @@ NSString* status = [NSString stringWithFormat:@"{\"current_position\": \"%@\"}",
 
     audioFileURL = [NSURL fileURLWithPath:[GetDirectoryOfType(NSCachesDirectory) stringByAppendingString:@"sound.m4a"]];
   } else {
-    audioFileURL = [NSURL fileURLWithPath: [GetDirectoryOfType(NSCachesDirectory) stringByAppendingString:path]];
+    audioFileURL = [NSURL fileURLWithPath: path];
   }
 
   NSMutableDictionary *audioSettings = [NSMutableDictionary dictionaryWithObjectsAndKeys:


### PR DESCRIPTION
I fixed both, the Android and IOS variant, but I only could test the Android variant.

So please check the IOS variant change since the fix was the first line of ObjectiveC I ever wrote.

The original code prefixes the given path given to ```startRecorder``` with another path, which results in a broken path.