### PR TITLE
[Release] Make ios & android audio format compatible by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.6.0
++ Set android default encoding option to `AAC`.
++ Fix android default poor sound.
+  - Resolve [#155](https://github.com/dooboolab/flutter_sound/issues/155)
+  - Resolve [#95](https://github.com/dooboolab/flutter_sound/issues/95)
+  - Resolve [#75](https://github.com/dooboolab/flutter_sound/issues/79)
 ## 1.5.2
 + Postfix `GetDirectoryType` to avoid conflicts [#147](https://github.com/dooboolab/flutter_sound/pull/147)
 ## 1.5.1

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ On *Android* you need to add a permission to `AndroidManifest.xml`:
 ## Default uri path
 When uri path is not set during the `function call` in `startRecorder` or `startPlayer`, they are saved in below path depending on the platform.
 + Default path for android
-  * `sdcard/sound.mp4`.
+  * `sdcard/sound.aac`.
 + Default path for ios
   * `sound.m4a`.
 
@@ -89,7 +89,7 @@ result.then(path) {
 
 If you want to take your own path specify it like below.
 ```
-String path = await flutterSound.startRecorder(Platform.isIOS ? 'ios.m4a' : 'android.mp4');
+String path = await flutterSound.startRecorder(Platform.isIOS ? 'ios.m4a' : 'android.aac');
 ```
 
 #### Stop recorder

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ When uri path is not set during the `function call` in `startRecorder` or `start
 + Default path for android
   * `sdcard/sound.aac`.
 + Default path for ios
-  * `sound.m4a`.
+  * `sound.aac`.
 
 ## Usage
 #### Creating instance.
@@ -89,7 +89,7 @@ result.then(path) {
 
 If you want to take your own path specify it like below.
 ```
-String path = await flutterSound.startRecorder(Platform.isIOS ? 'ios.m4a' : 'android.aac');
+String path = await flutterSound.startRecorder(Platform.isIOS ? 'ios.aac' : 'android.aac');
 ```
 
 #### Stop recorder

--- a/android/src/main/java/com/dooboolab/fluttersound/AudioInterface.java
+++ b/android/src/main/java/com/dooboolab/fluttersound/AudioInterface.java
@@ -3,7 +3,7 @@ package com.dooboolab.fluttersound;
 import io.flutter.plugin.common.MethodChannel;
 
 interface AudioInterface {
-  void startRecorder(int numChannels, int sampleRate, Integer bitRate, int androidEncoder, int androidAudioSource, int androidOutputFormat, String path, MethodChannel.Result result);
+  void startRecorder(Integer numChannels, Integer sampleRate, Integer bitRate, int androidEncoder, int androidAudioSource, int androidOutputFormat, String path, MethodChannel.Result result);
   void stopRecorder(MethodChannel.Result result);
   void startPlayer(String path, MethodChannel.Result result);
   void stopPlayer(MethodChannel.Result result);

--- a/android/src/main/java/com/dooboolab/fluttersound/AudioModel.java
+++ b/android/src/main/java/com/dooboolab/fluttersound/AudioModel.java
@@ -5,7 +5,7 @@ import android.media.MediaRecorder;
 import android.os.Environment;
 
 public class AudioModel {
-  final public static String DEFAULT_FILE_LOCATION = Environment.getExternalStorageDirectory().getPath() + "/default.m4a";
+  final public static String DEFAULT_FILE_LOCATION = Environment.getExternalStorageDirectory().getPath() + "/default.aac";
   public int subsDurationMillis = 10;
   public long peakLevelUpdateMillis = 800;
   public boolean shouldProcessDbLevel = true;

--- a/android/src/main/java/com/dooboolab/fluttersound/FlutterSoundPlugin.java
+++ b/android/src/main/java/com/dooboolab/fluttersound/FlutterSoundPlugin.java
@@ -61,10 +61,10 @@ public class FlutterSoundPlugin implements MethodCallHandler, PluginRegistry.Req
     switch (call.method) {
       case "startRecorder":
         taskScheduler.submit(() -> {
-          int sampleRate = call.argument("sampleRate");
-          int numChannels = call.argument("numChannels");
-          int androidEncoder = call.argument("androidEncoder");
+          Integer sampleRate = call.argument("sampleRate");
+          Integer numChannels = call.argument("numChannels");
           Integer bitRate = call.argument("bitRate");
+          int androidEncoder = call.argument("androidEncoder");
           int androidAudioSource = call.argument("androidAudioSource");
           int androidOutputFormat = call.argument("androidOutputFormat");
           startRecorder(numChannels, sampleRate, bitRate, androidEncoder, androidAudioSource, androidOutputFormat, path, result);
@@ -125,9 +125,8 @@ public class FlutterSoundPlugin implements MethodCallHandler, PluginRegistry.Req
   }
 
   @Override
-  public void startRecorder(int numChannels, int sampleRate, Integer bitRate, int androidEncoder, int androidAudioSource, int androidOutputFormat, String path, final Result result) {
+  public void startRecorder(Integer numChannels, Integer sampleRate, Integer bitRate, int androidEncoder, int androidAudioSource, int androidOutputFormat, String path, final Result result) {
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-
       if (
           reg.activity().checkSelfPermission(Manifest.permission.RECORD_AUDIO) != PackageManager.PERMISSION_GRANTED
               || reg.activity().checkSelfPermission(Manifest.permission.WRITE_EXTERNAL_STORAGE) != PackageManager.PERMISSION_GRANTED
@@ -152,13 +151,19 @@ public class FlutterSoundPlugin implements MethodCallHandler, PluginRegistry.Req
       this.model.getMediaRecorder().setAudioSource(androidAudioSource);
       this.model.getMediaRecorder().setOutputFormat(androidOutputFormat);
       this.model.getMediaRecorder().setAudioEncoder(androidEncoder);
-      this.model.getMediaRecorder().setAudioChannels(numChannels);
-      this.model.getMediaRecorder().setAudioSamplingRate(sampleRate);
 
       this.model.getMediaRecorder().setOutputFile(path);
 
-      // If bitrate is defined, the use it, otherwise use the OS default
-      if(bitRate != null){
+      if (numChannels != null) {
+        this.model.getMediaRecorder().setAudioChannels(numChannels);
+      }
+
+      if (sampleRate != null) {
+        this.model.getMediaRecorder().setAudioSamplingRate(sampleRate);
+      }
+
+      // If bitrate is defined, then use it, otherwise use the OS default
+      if (bitRate != null) {
         this.model.getMediaRecorder().setAudioEncodingBitRate(bitRate);
       }
     }

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -14,9 +14,9 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/flutter_sound/ios"
 
 SPEC CHECKSUMS:
-  Flutter: 58dd7d1b27887414a370fcccb9e645c08ffd7a6a
+  Flutter: 0e3d915762c693b495b44d77113d4970485de6ec
   flutter_sound: 0e8163ceac1e00eb6d894e2ae4641ba726a2c479
 
 PODFILE CHECKSUM: 1e5af4103afd21ca5ead147d7b81d06f494f51a2
 
-COCOAPODS: 1.8.1
+COCOAPODS: 1.8.4

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -5,6 +5,7 @@ import 'package:intl/date_symbol_data_local.dart';
 
 import 'dart:async';
 import 'package:flutter_sound/flutter_sound.dart';
+import 'package:flutter_sound/android_encoder.dart';
 
 void main() {
   runApp(new MyApp());
@@ -44,7 +45,11 @@ class _MyAppState extends State<MyApp> {
 
   void startRecorder() async{
     try {
-      String path = await flutterSound.startRecorder(Platform.isIOS ? 'ios.m4a' : 'android.mp4');
+      String path = await flutterSound.startRecorder(
+        Platform.isIOS ? 'ios.aac' : 'android.aac',
+        androidEncoder: AndroidEncoder.AAC,
+        androidAudioSource: AndroidAudioSource.MIC,
+      );
       print('startRecorder: $path');
 
       _recorderSubscription = flutterSound.onRecorderStateChanged.listen((e) {

--- a/ios/Classes/FlutterSoundPlugin.m
+++ b/ios/Classes/FlutterSoundPlugin.m
@@ -131,11 +131,23 @@ NSString* status = [NSString stringWithFormat:@"{\"current_position\": \"%@\"}",
 - (void)handleMethodCall:(FlutterMethodCall*)call result:(FlutterResult)result {
   if ([@"startRecorder" isEqualToString:call.method]) {
     NSString* path = (NSString*)call.arguments[@"path"];
-    NSNumber* sampleRate = (NSNumber*)call.arguments[@"sampleRate"];
-    NSNumber* numChannels = (NSNumber*)call.arguments[@"numChannels"];
+    NSNumber* sampleRateArgs = (NSNumber*)call.arguments[@"sampleRate"];
+    NSNumber* numChannelsArgs = (NSNumber*)call.arguments[@"numChannels"];
     NSNumber* iosQuality = (NSNumber*)call.arguments[@"iosQuality"];
     NSNumber* bitRate = (NSNumber*)call.arguments[@"bitRate"];
-      [self startRecorder:path:numChannels:sampleRate:iosQuality:bitRate result:result];
+
+    float sampleRate = 16000;
+    if (![sampleRateArgs isKindOfClass:[NSNull class]]) {
+      sampleRate = [sampleRateArgs integerValue];
+    }
+
+    int numChannels = 1;
+    if (![numChannelsArgs isKindOfClass:[NSNull class]]) {
+      numChannels = [numChannelsArgs integerValue];
+    }
+
+    [self startRecorder:path:[NSNumber numberWithInt:numChannels]:[NSNumber numberWithInt:sampleRate]:iosQuality:bitRate result:result];
+
   } else if ([@"stopRecorder" isEqualToString:call.method]) {
     [self stopRecorder:result];
   } else if ([@"startPlayer" isEqualToString:call.method]) {

--- a/ios/Classes/FlutterSoundPlugin.m
+++ b/ios/Classes/FlutterSoundPlugin.m
@@ -136,12 +136,12 @@ NSString* status = [NSString stringWithFormat:@"{\"current_position\": \"%@\"}",
     NSNumber* iosQuality = (NSNumber*)call.arguments[@"iosQuality"];
     NSNumber* bitRate = (NSNumber*)call.arguments[@"bitRate"];
 
-    float sampleRate = 16000;
+    float sampleRate = 44100;
     if (![sampleRateArgs isKindOfClass:[NSNull class]]) {
       sampleRate = [sampleRateArgs integerValue];
     }
 
-    int numChannels = 1;
+    int numChannels = 2;
     if (![numChannelsArgs isKindOfClass:[NSNull class]]) {
       numChannels = [numChannelsArgs integerValue];
     }

--- a/ios/Classes/FlutterSoundPlugin.m
+++ b/ios/Classes/FlutterSoundPlugin.m
@@ -200,7 +200,7 @@ NSString* status = [NSString stringWithFormat:@"{\"current_position\": \"%@\"}",
 - (void)startRecorder :(NSString*)path :(NSNumber*)numChannels :(NSNumber*)sampleRate :(NSNumber*)iosQuality :(NSNumber*)bitRate result: (FlutterResult)result {
   if ([path class] == [NSNull class]) {
 
-    audioFileURL = [NSURL fileURLWithPath:[GetDirectoryOfType_FlutterSound(NSCachesDirectory) stringByAppendingString:@"sound.m4a"]];
+    audioFileURL = [NSURL fileURLWithPath:[GetDirectoryOfType_FlutterSound(NSCachesDirectory) stringByAppendingString:@"sound.aac"]];
   } else {
     audioFileURL = [NSURL fileURLWithPath: [GetDirectoryOfType_FlutterSound(NSCachesDirectory) stringByAppendingString:path]];
   }
@@ -265,7 +265,7 @@ NSString* status = [NSString stringWithFormat:@"{\"current_position\": \"%@\"}",
 - (void)startPlayer:(NSString*)path result: (FlutterResult)result {
   bool isRemote = false;
   if ([path class] == [NSNull class]) {
-    audioFileURL = [NSURL fileURLWithPath:[GetDirectoryOfType_FlutterSound(NSCachesDirectory) stringByAppendingString:@"sound.m4a"]];
+    audioFileURL = [NSURL fileURLWithPath:[GetDirectoryOfType_FlutterSound(NSCachesDirectory) stringByAppendingString:@"sound.aac"]];
   } else {
     NSURL *remoteUrl = [NSURL URLWithString:path];
     if(remoteUrl && remoteUrl.scheme && remoteUrl.host){

--- a/lib/android_encoder.dart
+++ b/lib/android_encoder.dart
@@ -17,6 +17,7 @@ class AndroidEncoder {
   static const AAC_ELD = const AndroidEncoder._internal(5);
   /// Enhanced Low Delay AAC (AAC-ELD) audio codec
   static const VORBIS = const AndroidEncoder._internal(6);
+  static const OPUS = const AndroidEncoder._internal(7);
 }
 
 class AndroidAudioSource {
@@ -49,10 +50,10 @@ class AndroidOutputFormat {
   static const MPEG_4 = const AndroidOutputFormat._internal(2);
   static const AMR_NB = const AndroidOutputFormat._internal(3);
   static const AMR_WB = const AndroidOutputFormat._internal(4);
-  static const AAC_ADIF = const AndroidOutputFormat._internal(5);
   static const AAC_ADTS = const AndroidOutputFormat._internal(6);
   static const OUTPUT_FORMAT_RTP_AVP = const AndroidOutputFormat._internal(7);
   static const MPEG_2_TS = const AndroidOutputFormat._internal(8);
   static const WEBM = const AndroidOutputFormat._internal(9);
+  static const OGG = const AndroidOutputFormat._internal(11);
 }
 

--- a/lib/flutter_sound.dart
+++ b/lib/flutter_sound.dart
@@ -112,8 +112,8 @@ class FlutterSound {
   }
 
   Future<String> startRecorder(String uri,
-      {int sampleRate = 44100, int numChannels = 2, int bitRate,
-        AndroidEncoder androidEncoder = AndroidEncoder.DEFAULT,
+      {int sampleRate, int numChannels, int bitRate,
+        AndroidEncoder androidEncoder = AndroidEncoder.AAC,
         AndroidAudioSource androidAudioSource = AndroidAudioSource.MIC,
         AndroidOutputFormat androidOutputFormat = AndroidOutputFormat.MPEG_4,
         IosQuality iosQuality = IosQuality.LOW,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_sound
 description: Flutter plugin that relates to sound like audio and recorder.
-version: 1.5.2
+version: 1.6.0
 author: dooboolab<dooboolab@gmail.com>
 homepage: https://github.com/dooboolab/flutter_sound
 environment:


### PR DESCRIPTION
1.6.0
+ Set android default encoding option to `AAC`.
+ Fix android default poor sound.
  - Resolve [#155](https://github.com/dooboolab/flutter_sound/issues/155)
  - Resolve [#95](https://github.com/dooboolab/flutter_sound/issues/95)
  - Resolve [#75](https://github.com/dooboolab/flutter_sound/issues/79)+ Set android default encoding option to `AAC`.
+ Fix android default poor sound.
  - Resolve [#155](https://github.com/dooboolab/flutter_sound/issues/155)
  - Resolve [#95](https://github.com/dooboolab/flutter_sound/issues/95)
  - Resolve [#75](https://github.com/dooboolab/flutter_sound/issues/79)