### PR TITLE
Fixes returned filePath on iOS

### DIFF
--- a/ios/Classes/FlutterSoundPlugin.m
+++ b/ios/Classes/FlutterSoundPlugin.m
@@ -243,7 +243,7 @@ NSString* status = [NSString stringWithFormat:@"{\"current_position\": \"%@\"}",
         [self startDbTimer];
   }
 
-  NSString *filePath = self->audioFileURL.absoluteString;
+  NSString *filePath = self->audioFileURL.path;
   result(filePath);
 }
 


### PR DESCRIPTION
Actually it returns the absolute string of a so called file URL which starts with `file:///`. This isn't a POSIX compliant file path which always starts with a slash `/`.

The Android version of this plugin returns the result of `getPath` which gives us a POSIX compliant path, too.

@hyochan It would be very nice to have this PR in a current release of the plugin as soon as possible. Actually we are working with our fixed fork, which we would like to get rid of. Thanks a lot!