### PR TITLE
Android minSdkVersion is 22 instead of 23. SDK before 22 fails

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,7 +25,7 @@ android {
     compileSdkVersion 29
 
     defaultConfig {
-        minSdkVersion 23
+        minSdkVersion 22
     }
     lintOptions {
         disable 'InvalidPackage'

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -34,7 +34,7 @@ android {
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.dooboolab.fluttersoundexample"
-        minSdkVersion 23
+        minSdkVersion 22
         targetSdkVersion 29
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName


### PR DESCRIPTION
Android MinSdkVersion is 22 instead of 23. SDK prior to 22 crashes on recorder.stop().

Issue: minsdk 23 [question] #174