### PR TITLE
Use AAC-LC format instead of MPEG-4

### DIFF
--- a/android/src/main/java/com/dooboolab/fluttersound/FlutterSoundPlugin.java
+++ b/android/src/main/java/com/dooboolab/fluttersound/FlutterSoundPlugin.java
@@ -111,8 +111,8 @@ public class FlutterSoundPlugin implements MethodCallHandler, PluginRegistry.Req
   };
 
   static int formatsArray[] = {
-      MediaRecorder.OutputFormat.MPEG_4 // DEFAULT
-    , MediaRecorder.OutputFormat.MPEG_4 // CODEC_AAC
+      MediaRecorder.OutputFormat.AAC_ADTS // DEFAULT
+    , MediaRecorder.OutputFormat.AAC_ADTS // CODEC_AAC
     , sdkCompat.OUTPUT_FORMAT_OGG       // CODEC_OPUS
     , 0                                 // CODEC_CAF_OPUS (this is apple specific)
     , 0                                 // CODEC_MP3


### PR DESCRIPTION
At the moment we use MPEG-4 as format for android recordings and AAC LC for ios recordings. This PR sets AAC LC as default for AAC recordings under android to have the same formats as under ios.

This may be breaking. 