### PR TITLE
Fix path issue when playing audio on android

### DIFF
--- a/android/src/main/java/com/dooboolab/fluttersound/FlutterSoundPlugin.java
+++ b/android/src/main/java/com/dooboolab/fluttersound/FlutterSoundPlugin.java
@@ -4,6 +4,7 @@ import android.Manifest;
 import android.content.pm.PackageManager;
 import android.media.MediaPlayer;
 import android.media.MediaRecorder;
+import android.net.Uri;
 import android.os.Build;
 import android.os.Handler;
 import android.os.SystemClock;
@@ -420,7 +421,9 @@ public class FlutterSoundPlugin implements MethodCallHandler, PluginRegistry.Req
       if (path == null) {
         this.model.getMediaPlayer().setDataSource(AudioModel.DEFAULT_FILE_LOCATION);
       } else {
-        this.model.getMediaPlayer().setDataSource(path);
+        Uri uriFileName = Uri.fromFile(new File(path));
+        String uriStr = uriFileName.toString();
+        this.model.getMediaPlayer().setDataSource(uriStr);
       }
 
       this.model.getMediaPlayer().setOnPreparedListener(mp -> {
@@ -486,6 +489,8 @@ public class FlutterSoundPlugin implements MethodCallHandler, PluginRegistry.Req
     } catch (Exception e) {
       Log.e(TAG, "startPlayer() exception");
       result.error(ERR_UNKNOWN, ERR_UNKNOWN, e.getMessage());
+//      Log.e(TAG, e.getStackTrace().toString());
+//      Log.e(TAG, Thread.currentThread().getStackTrace().toString());
     }
   }
 

--- a/android/src/main/java/com/dooboolab/fluttersound/FlutterSoundPlugin.java
+++ b/android/src/main/java/com/dooboolab/fluttersound/FlutterSoundPlugin.java
@@ -489,8 +489,6 @@ public class FlutterSoundPlugin implements MethodCallHandler, PluginRegistry.Req
     } catch (Exception e) {
       Log.e(TAG, "startPlayer() exception");
       result.error(ERR_UNKNOWN, ERR_UNKNOWN, e.getMessage());
-//      Log.e(TAG, e.getStackTrace().toString());
-//      Log.e(TAG, Thread.currentThread().getStackTrace().toString());
     }
   }
 


### PR DESCRIPTION
# Flutter Doctor
```Doctor summary (to see all details, run flutter doctor -v):
[✓] Flutter (Channel stable, v1.12.13+hotfix.8, on Mac OS X 10.15.3
    19D76, locale en-US)

[✓] Android toolchain - develop for Android devices (Android SDK
    version 29.0.2)
[✓] Xcode - develop for iOS and macOS (Xcode 11.3.1)
[✓] Android Studio (version 3.6)
[✓] VS Code (version 1.42.1)
[✓] Connected device (1 available)
```

# Android issue
Tested on a real device (Galaxy Note 9) 

## Expected behavior
Calling startPlayer() with the path of an audio file on external storage actually plays the file. 

## Actual behavior
Result is an error. After investigating futher, the `prepare()` method was causing the issue. The path desired path to the file should start with `file://`. 

Here is the flutter log for the error:

```I/flutter (19693): startPlayer called
I/flutter (19693): playing status: t_AUDIO_STATE.IS_STOPPED
I/flutter (19693): stopping player
I/flutter (19693): stopPlayer called
I/flutter (19693): playing status: t_AUDIO_STATE.IS_STOPPED
I/flutter (19693): playing file
I/flutter (19693): /data/user/0/com.claptimes.myapp/app_flutter/my_app/2020-02-25T11:50:24.165751.acc
V/MediaPlayer-JNI(19693): native_setup
V/MediaPlayerNative(19693): constructor
V/MediaPlayerNative(19693): setListener
V/MediaPlayerNative(19693): setVideoSurfaceTexture
V/MediaPlayerNative(19693): prepare
V/MediaPlayerNative(19693): message received msg=300, ext1=0, ext2=0
V/MediaPlayerNative(19693): Received SEC_MM_PLAYER_CONTEXT_AWARE
V/MediaPlayerNative(19693): callback application
V/MediaPlayerNative(19693): back from callback
V/MediaPlayerNative(19693): message received msg=100, ext1=1, ext2=-2147483648
E/MediaPlayerNative(19693): error (1, -2147483648)
V/MediaPlayerNative(19693): signal application thread
V/MediaPlayerNative(19693): prepare complete - status=1
E/FlutterSoundPlugin(19693): startPlayer() exception
I/flutter (19693): error: Exception: PlatformException(ERR_UNKNOWN, ERR_UNKNOWN, Prepare failed.: status=0x1)
I/flutter (19693): stopPlayer called
I/flutter (19693): playing status: t_AUDIO_STATE.IS_STOPPED
```

# Fix
Prefixing the path string with `file://` resolves the issues. I've included a PR which works on my device. 