### PR TITLE
Fix error on documentation for Android FFmpeg setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Please, look to [flutter_ffmpeg documentation](https://pub.dev/packages/flutter_
   end
 ```
 
-- On Android you will have to enter the following line in your `pubspec.yaml` file.
+- On Android you will have to enter the following line in your `android/build.gradle` file.
 
 ```
 ext.flutterFFmpegPackage = 'audio-lts'


### PR DESCRIPTION
The README file says that you should enter
ext.flutterFFmpegPackage = 'audio-lts' on the pubspec.yaml,
when in reality, it should be into the android/gradle.build file.