### PR TITLE
Added requestPermission argument with default value true

### DIFF
--- a/lib/flutter_sound_recorder.dart
+++ b/lib/flutter_sound_recorder.dart
@@ -266,11 +266,14 @@ class FlutterSoundRecorder {
     AndroidAudioSource androidAudioSource = AndroidAudioSource.MIC,
     AndroidOutputFormat androidOutputFormat = AndroidOutputFormat.DEFAULT,
     IosQuality iosQuality = IosQuality.LOW,
+    bool requestPermission = true,
   }) async {
     initialize();
     // Request Microphone permission if needed
-     PermissionStatus status = await Permission.microphone.request();
-    if (status != PermissionStatus.granted) throw new Exception("Microphone permission not granted");
+    if (requestPermission) {
+      PermissionStatus status = await Permission.microphone.request();
+      if (status != PermissionStatus.granted) throw new Exception("Microphone permission not granted");
+    }
 
     if (recorderState != null && recorderState != t_RECORDER_STATE.IS_STOPPED) {
       throw new RecorderRunningException('Recorder is not stopped.');


### PR DESCRIPTION
To avoid permission_handler unable to detect current activity error in foreground service, we should get permission outside of the service.