### PR TITLE
Fixed: parameters androidOutputFormat and androidEncoder are ignored

### DIFF
--- a/android/src/main/java/com/dooboolab/fluttersound/FlutterSoundRecorder.java
+++ b/android/src/main/java/com/dooboolab/fluttersound/FlutterSoundRecorder.java
@@ -392,11 +392,11 @@ public class FlutterSoundRecorder
 			Integer      sampleRate          = call.argument ( "sampleRate" );
 			Integer      numChannels         = call.argument ( "numChannels" );
 			Integer      bitRate             = call.argument ( "bitRate" );
-			int          androidEncoder      = call.argument ( "androidEncoder" );
+			Integer      androidEncoder      = call.argument ( "androidEncoder" );
 			int          _codec              = call.argument ( "codec" );
 			t_CODEC      codec               = t_CODEC.values ()[ _codec ];
 			int          androidAudioSource  = call.argument ( "androidAudioSource" );
-			int          androidOutputFormat = call.argument ( "androidOutputFormat" );
+			Integer      androidOutputFormat = call.argument ( "androidOutputFormat" );
 			final String path                = call.argument ( "path" );
 			_startRecorder ( numChannels, sampleRate, bitRate, codec, androidEncoder, androidAudioSource, androidOutputFormat, path, result );
 		}
@@ -405,7 +405,7 @@ public class FlutterSoundRecorder
 	}
 
 	public void _startRecorder (
-		Integer numChannels, Integer sampleRate, Integer bitRate, t_CODEC codec, int androidEncoder, int androidAudioSource, int androidOutputFormat, String path, final Result result
+		Integer numChannels, Integer sampleRate, Integer bitRate, t_CODEC codec, Integer androidEncoder, int androidAudioSource, Integer androidOutputFormat, String path, final Result result
 	                           )
 	{
 		final int v = Build.VERSION.SDK_INT;
@@ -434,8 +434,17 @@ public class FlutterSoundRecorder
 			}
 			mediaRecorder.reset();
 			mediaRecorder.setAudioSource ( androidAudioSource );
-			androidEncoder      = codecArray[ codec.ordinal () ];
-			androidOutputFormat = formatsArray[ codec.ordinal () ];
+
+			// If encoder is defined, then use it, otherwise use the auto detection by codec
+			if (androidEncoder == null) {
+				androidEncoder      = codecArray[ codec.ordinal () ];
+			}
+
+			// If output format is defined, then use it, otherwise use the auto detection by codec
+			if (androidOutputFormat == null) {
+				androidOutputFormat = formatsArray[codec.ordinal()];
+			}
+
 			mediaRecorder.setOutputFormat ( androidOutputFormat );
 
 			if ( path == null )

--- a/lib/flutter_sound_recorder.dart
+++ b/lib/flutter_sound_recorder.dart
@@ -284,15 +284,19 @@ class FlutterSoundRecorder {
     return fout.path;
   }
 
+  /// Starts record.
+  /// 
+  /// If [androidOutputFormat] is null (default) - it will be auto detected by [codec].
+  /// If [androidEncoder] is null (default) - it will be auto detected by [codec].
   Future<String> startRecorder({
     String uri,
     int sampleRate = 16000,
     int numChannels = 1,
     int bitRate = 16000,
     t_CODEC codec = t_CODEC.CODEC_AAC,
-    AndroidEncoder androidEncoder = AndroidEncoder.AAC,
+    AndroidEncoder androidEncoder,
     AndroidAudioSource androidAudioSource = AndroidAudioSource.MIC,
-    AndroidOutputFormat androidOutputFormat = AndroidOutputFormat.DEFAULT,
+    AndroidOutputFormat androidOutputFormat,
     IosQuality iosQuality = IosQuality.LOW,
     bool requestPermission = true,
   }) async {


### PR DESCRIPTION
Now parameters `androidOutputFormat` and `androidEncoder` used as is if defined, and automatically resolved if `null` (this is default behaviour, so nothin changed by default).

Some additional information.
I need this parameters because of bug on some Android 5 devices - audio recorded but not played with default output format, which is `OutputFormat.AAC_ADTS`. It is working if use `OutputFormat.DEFAULT` or `OutputFormat.MPEG_4`, but I'm not sure that it is a wright way to fix it. That's why I decide to not change android recorder implementation, but just add an ability to set output format from application code (since this parameter defined in package).