### PR TITLE
#370 : Android : Close recorder when not recording

### DIFF
--- a/android/src/main/java/com/dooboolab/fluttersound/FlutterSoundMediaRecorder.java
+++ b/android/src/main/java/com/dooboolab/fluttersound/FlutterSoundMediaRecorder.java
@@ -31,8 +31,8 @@ public class FlutterSoundMediaRecorder
 	final static String             TAG                = "SoundMediaRecorder";
 
 	static int codecArray[] = {
-		0 // DEFAULT
-		, MediaRecorder.AudioEncoder.DEFAULT,
+               MediaRecorder.AudioEncoder.DEFAULT,
+                MediaRecorder.AudioEncoder.AAC,
 		sdkCompat.AUDIO_ENCODER_OPUS,
 		0, // CODEC_CAF_OPUS (specific Apple)
 		0,// CODEC_MP3 (not implemented)

--- a/android/src/main/java/com/dooboolab/fluttersound/FlutterSoundRecorder.java
+++ b/android/src/main/java/com/dooboolab/fluttersound/FlutterSoundRecorder.java
@@ -404,7 +404,10 @@ public class FlutterSoundRecorder extends Session
 	public void stopRecorder ( final MethodCall call, final Result result )
 	{
 		recordHandler.removeCallbacksAndMessages ( null );
-		recorder._stopRecorder (  );
+		if (recorder != null)
+		{
+			recorder._stopRecorder();
+		}
 		recorder = null;
 		result.success ( "Media Recorder is closed" );
 	}


### PR DESCRIPTION
```closeRecorder``` is supposed to always work without throwing any exception.
This verb was not correctly protected on Android.
[#370]