### PR TITLE
Correct copy/paste albumArtFile assignment error

### DIFF
--- a/ios/Classes/Track.m
+++ b/ios/Classes/Track.m
@@ -63,7 +63,7 @@
         albumArtAsset = albumArtAssetString;
         
         NSString *albumArtFileString = [responseObj objectForKey:@"albumArtFile"];
-        albumArtFile = albumArtAssetString;
+        albumArtFile = albumArtFileString;
 
 
         FlutterStandardTypedData *dataBufferJson = [responseObj objectForKey:@"dataBuffer"];


### PR DESCRIPTION
Was previously being assigned from albumArtAssetString, clearly that stanza copied and incompletely edited into this one!

Spotted by Xcode ;)