### PR TITLE
Update logger package to ^0.9.4

### DIFF
--- a/flutter_sound/lib/src/util/log.dart
+++ b/flutter_sound/lib/src/util/log.dart
@@ -16,9 +16,8 @@
  * along with Flutter-Sound.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-
 import 'package:intl/intl.dart';
-import 'package:logger/logger.dart';
+import 'package:logger/logger.dart' hide AnsiColor;
 
 import 'ansi_color.dart';
 import 'enum_helper.dart';
@@ -148,11 +147,11 @@ class MyLogPrinter extends LogPrinter {
   MyLogPrinter(this.currentWorkingDirectory);
 
   @override
-  void log(LogEvent event) {
+  List<String> log(LogEvent event) {
     if (EnumHelper.getIndexOf(Level.values, Log.loggingLevel) >
         EnumHelper.getIndexOf(Level.values, event.level)) {
       // don't log events where the log level is set higher
-      return;
+      return null;
     }
     var formatter = DateFormat('dd HH:mm:ss.');
     var now = DateTime.now();

--- a/flutter_sound/pubspec.yaml
+++ b/flutter_sound/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
     flutter: ">=1.12.0 <2.0.0"
 dependencies:
   path_provider: ">=1.0.0 <2.0.0"
-  logger: ^0.7.0+2
+  logger: ^0.9.4
   intl: ^0.16.1
   recase: ^3.0.0
   uuid: ^2.0.4


### PR DESCRIPTION
Signed-off-by: Ayush P Gupta <ayushpguptaapg@gmail.com>

Currently i am using logger package in one of library in main project but due to old logger version in flutter_sound, it cause error of mismatch version